### PR TITLE
Add ETHRelayer for Contribution Reward scheme

### DIFF
--- a/contracts/utils/ETHRelayer.sol
+++ b/contracts/utils/ETHRelayer.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.7.6;
+
+/**
+ * @title ETHRelayer
+ * @dev Ether relayer used to relay all ether received in this contract to the receiver address.
+ * Receives ETH via legacy .transfer function using defualt 23000 gas limit and relay it using 100k gas limit to 
+ * contracts that have enabled the fallback payable funciton.
+ */
+contract ETHRelayer{
+    
+    address payable public receiver;
+    
+    constructor(address payable _receiver) public {
+        receiver = _receiver;
+    }
+    
+    receive() external payable {}
+    
+    function relay() public {
+      (bool success,) = receiver.call{gas: 100000, value: address(this).balance}("");
+      require(success, "ETHRelayer: Relay transfer failed");
+    }
+    
+}

--- a/contracts/utils/GnosisSafe/GnosisProxy.sol
+++ b/contracts/utils/GnosisSafe/GnosisProxy.sol
@@ -1,0 +1,45 @@
+/**
+ * Taken from https://etherscan.io/address/0x5f239a6671bc6d2baef6d7cd892296e678810882#code
+*/
+
+pragma solidity ^0.5.3;
+
+/// @title GnosisProxy - Generic proxy contract allows to execute all transactions applying the code of a master contract.
+/// @author Stefan George - <stefan@gnosis.io>
+/// @author Richard Meissner - <richard@gnosis.io>
+contract GnosisProxy {
+
+    // masterCopy always needs to be first declared variable, to ensure that it is at the same location in the contracts to which calls are delegated.
+    // To reduce deployment costs this variable is internal and needs to be retrieved via `getStorageAt`
+    address internal masterCopy;
+
+    /// @dev Constructor function sets address of master copy contract.
+    /// @param _masterCopy Master copy address.
+    constructor(address _masterCopy)
+        public
+    {
+        require(_masterCopy != address(0), "Invalid master copy address provided");
+        masterCopy = _masterCopy;
+    }
+
+    /// @dev Fallback function forwards all transactions and returns all received return data.
+    function ()
+        external
+        payable
+    {
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            let masterCopy := and(sload(0), 0xffffffffffffffffffffffffffffffffffffffff)
+            // 0xa619486e == keccak("masterCopy()"). The value is right padded to 32-bytes with 0s
+            if eq(calldataload(0), 0xa619486e00000000000000000000000000000000000000000000000000000000) {
+                mstore(0, masterCopy)
+                return(0, 0x20)
+            }
+            calldatacopy(0, 0, calldatasize())
+            let success := delegatecall(gas, masterCopy, 0, calldatasize(), 0, 0)
+            returndatacopy(0, 0, returndatasize())
+            if eq(success, 0) { revert(0, returndatasize()) }
+            return(0, returndatasize())
+        }
+    }
+}

--- a/contracts/utils/GnosisSafe/GnosisSafe.sol
+++ b/contracts/utils/GnosisSafe/GnosisSafe.sol
@@ -1,0 +1,1080 @@
+/**
+ * Taken from https://etherscan.io/address/0x34cfac646f301356faa8b21e94227e3583fe3f5f#code
+*/
+
+pragma solidity >=0.5.0 <0.7.0;
+
+/// @title SelfAuthorized - authorizes current contract to perform actions
+/// @author Richard Meissner - <richard@gnosis.pm>
+contract SelfAuthorized {
+    modifier authorized() {
+        require(msg.sender == address(this), "Method can only be called from this contract");
+        _;
+    }
+}
+
+
+
+/// @title MasterCopy - Base for master copy contracts (should always be first super contract)
+///         This contract is tightly coupled to our proxy contract (see `proxies/Proxy.sol`)
+/// @author Richard Meissner - <richard@gnosis.io>
+contract MasterCopy is SelfAuthorized {
+
+    event ChangedMasterCopy(address masterCopy);
+
+    // masterCopy always needs to be first declared variable, to ensure that it is at the same location as in the Proxy contract.
+    // It should also always be ensured that the address is stored alone (uses a full word)
+    address private masterCopy;
+
+    /// @dev Allows to upgrade the contract. This can only be done via a Safe transaction.
+    /// @param _masterCopy New contract address.
+    function changeMasterCopy(address _masterCopy)
+        public
+        authorized
+    {
+        // Master copy address cannot be null.
+        require(_masterCopy != address(0), "Invalid master copy address provided");
+        masterCopy = _masterCopy;
+        emit ChangedMasterCopy(_masterCopy);
+    }
+}
+
+
+/// @title Module - Base class for modules.
+/// @author Stefan George - <stefan@gnosis.pm>
+/// @author Richard Meissner - <richard@gnosis.pm>
+contract Module is MasterCopy {
+
+    ModuleManager public manager;
+
+    modifier authorized() {
+        require(msg.sender == address(manager), "Method can only be called from manager");
+        _;
+    }
+
+    function setManager()
+        internal
+    {
+        // manager can only be 0 at initalization of contract.
+        // Check ensures that setup function can only be called once.
+        require(address(manager) == address(0), "Manager has already been set");
+        manager = ModuleManager(msg.sender);
+    }
+}
+
+
+
+
+
+/// @title Enum - Collection of enums
+/// @author Richard Meissner - <richard@gnosis.pm>
+contract Enum {
+    enum Operation {
+        Call,
+        DelegateCall
+    }
+}
+
+
+
+
+
+/// @title Executor - A contract that can execute transactions
+/// @author Richard Meissner - <richard@gnosis.pm>
+contract Executor {
+
+    function execute(address to, uint256 value, bytes memory data, Enum.Operation operation, uint256 txGas)
+        internal
+        returns (bool success)
+    {
+        if (operation == Enum.Operation.Call)
+            success = executeCall(to, value, data, txGas);
+        else if (operation == Enum.Operation.DelegateCall)
+            success = executeDelegateCall(to, data, txGas);
+        else
+            success = false;
+    }
+
+    function executeCall(address to, uint256 value, bytes memory data, uint256 txGas)
+        internal
+        returns (bool success)
+    {
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            success := call(txGas, to, value, add(data, 0x20), mload(data), 0, 0)
+        }
+    }
+
+    function executeDelegateCall(address to, bytes memory data, uint256 txGas)
+        internal
+        returns (bool success)
+    {
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            success := delegatecall(txGas, to, add(data, 0x20), mload(data), 0, 0)
+        }
+    }
+}
+
+
+
+/// @title SecuredTokenTransfer - Secure token transfer
+/// @author Richard Meissner - <richard@gnosis.pm>
+contract SecuredTokenTransfer {
+
+    /// @dev Transfers a token and returns if it was a success
+    /// @param token Token that should be transferred
+    /// @param receiver Receiver to whom the token should be transferred
+    /// @param amount The amount of tokens that should be transferred
+    function transferToken (
+        address token,
+        address receiver,
+        uint256 amount
+    )
+        internal
+        returns (bool transferred)
+    {
+        bytes memory data = abi.encodeWithSignature("transfer(address,uint256)", receiver, amount);
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            let success := call(sub(gas, 10000), token, 0, add(data, 0x20), mload(data), 0, 0)
+            let ptr := mload(0x40)
+            mstore(0x40, add(ptr, returndatasize()))
+            returndatacopy(ptr, 0, returndatasize())
+            switch returndatasize()
+            case 0 { transferred := success }
+            case 0x20 { transferred := iszero(or(iszero(success), iszero(mload(ptr)))) }
+            default { transferred := 0 }
+        }
+    }
+}
+
+
+
+
+
+
+
+
+
+
+/// @title Module Manager - A contract that manages modules that can execute transactions via this contract
+/// @author Stefan George - <stefan@gnosis.pm>
+/// @author Richard Meissner - <richard@gnosis.pm>
+contract ModuleManager is SelfAuthorized, Executor {
+
+    event EnabledModule(Module module);
+    event DisabledModule(Module module);
+    event ExecutionFromModuleSuccess(address indexed module);
+    event ExecutionFromModuleFailure(address indexed module);
+
+    address internal constant SENTINEL_MODULES = address(0x1);
+
+    mapping (address => address) internal modules;
+
+    function setupModules(address to, bytes memory data)
+        internal
+    {
+        require(modules[SENTINEL_MODULES] == address(0), "Modules have already been initialized");
+        modules[SENTINEL_MODULES] = SENTINEL_MODULES;
+        if (to != address(0))
+            // Setup has to complete successfully or transaction fails.
+            require(executeDelegateCall(to, data, gasleft()), "Could not finish initialization");
+    }
+
+    /// @dev Allows to add a module to the whitelist.
+    ///      This can only be done via a Safe transaction.
+    /// @param module Module to be whitelisted.
+    function enableModule(Module module)
+        public
+        authorized
+    {
+        // Module address cannot be null or sentinel.
+        require(address(module) != address(0) && address(module) != SENTINEL_MODULES, "Invalid module address provided");
+        // Module cannot be added twice.
+        require(modules[address(module)] == address(0), "Module has already been added");
+        modules[address(module)] = modules[SENTINEL_MODULES];
+        modules[SENTINEL_MODULES] = address(module);
+        emit EnabledModule(module);
+    }
+
+    /// @dev Allows to remove a module from the whitelist.
+    ///      This can only be done via a Safe transaction.
+    /// @param prevModule Module that pointed to the module to be removed in the linked list
+    /// @param module Module to be removed.
+    function disableModule(Module prevModule, Module module)
+        public
+        authorized
+    {
+        // Validate module address and check that it corresponds to module index.
+        require(address(module) != address(0) && address(module) != SENTINEL_MODULES, "Invalid module address provided");
+        require(modules[address(prevModule)] == address(module), "Invalid prevModule, module pair provided");
+        modules[address(prevModule)] = modules[address(module)];
+        modules[address(module)] = address(0);
+        emit DisabledModule(module);
+    }
+
+    /// @dev Allows a Module to execute a Safe transaction without any further confirmations.
+    /// @param to Destination address of module transaction.
+    /// @param value Ether value of module transaction.
+    /// @param data Data payload of module transaction.
+    /// @param operation Operation type of module transaction.
+    function execTransactionFromModule(address to, uint256 value, bytes memory data, Enum.Operation operation)
+        public
+        returns (bool success)
+    {
+        // Only whitelisted modules are allowed.
+        require(msg.sender != SENTINEL_MODULES && modules[msg.sender] != address(0), "Method can only be called from an enabled module");
+        // Execute transaction without further confirmations.
+        success = execute(to, value, data, operation, gasleft());
+        if (success) emit ExecutionFromModuleSuccess(msg.sender);
+        else emit ExecutionFromModuleFailure(msg.sender);
+    }
+
+    /// @dev Allows a Module to execute a Safe transaction without any further confirmations and return data
+    /// @param to Destination address of module transaction.
+    /// @param value Ether value of module transaction.
+    /// @param data Data payload of module transaction.
+    /// @param operation Operation type of module transaction.
+    function execTransactionFromModuleReturnData(address to, uint256 value, bytes memory data, Enum.Operation operation)
+        public
+        returns (bool success, bytes memory returnData)
+    {
+        success = execTransactionFromModule(to, value, data, operation);
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            // Load free memory location
+            let ptr := mload(0x40)
+            // We allocate memory for the return data by setting the free memory location to
+            // current free memory location + data size + 32 bytes for data size value
+            mstore(0x40, add(ptr, add(returndatasize(), 0x20)))
+            // Store the size
+            mstore(ptr, returndatasize())
+            // Store the data
+            returndatacopy(add(ptr, 0x20), 0, returndatasize())
+            // Point the return data to the correct memory location
+            returnData := ptr
+        }
+    }
+
+    /// @dev Returns array of first 10 modules.
+    /// @return Array of modules.
+    function getModules()
+        public
+        view
+        returns (address[] memory)
+    {
+        (address[] memory array,) = getModulesPaginated(SENTINEL_MODULES, 10);
+        return array;
+    }
+
+    /// @dev Returns array of modules.
+    /// @param start Start of the page.
+    /// @param pageSize Maximum number of modules that should be returned.
+    /// @return Array of modules.
+    function getModulesPaginated(address start, uint256 pageSize)
+        public
+        view
+        returns (address[] memory array, address next)
+    {
+        // Init array with max page size
+        array = new address[](pageSize);
+
+        // Populate return array
+        uint256 moduleCount = 0;
+        address currentModule = modules[start];
+        while(currentModule != address(0x0) && currentModule != SENTINEL_MODULES && moduleCount < pageSize) {
+            array[moduleCount] = currentModule;
+            currentModule = modules[currentModule];
+            moduleCount++;
+        }
+        next = currentModule;
+        // Set correct size of returned array
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            mstore(array, moduleCount)
+        }
+    }
+}
+
+
+
+
+/// @title OwnerManager - Manages a set of owners and a threshold to perform actions.
+/// @author Stefan George - <stefan@gnosis.pm>
+/// @author Richard Meissner - <richard@gnosis.pm>
+contract OwnerManager is SelfAuthorized {
+
+    event AddedOwner(address owner);
+    event RemovedOwner(address owner);
+    event ChangedThreshold(uint256 threshold);
+
+    address internal constant SENTINEL_OWNERS = address(0x1);
+
+    mapping(address => address) internal owners;
+    uint256 ownerCount;
+    uint256 internal threshold;
+
+    /// @dev Setup function sets initial storage of contract.
+    /// @param _owners List of Safe owners.
+    /// @param _threshold Number of required confirmations for a Safe transaction.
+    function setupOwners(address[] memory _owners, uint256 _threshold)
+        internal
+    {
+        // Threshold can only be 0 at initialization.
+        // Check ensures that setup function can only be called once.
+        require(threshold == 0, "Owners have already been setup");
+        // Validate that threshold is smaller than number of added owners.
+        require(_threshold <= _owners.length, "Threshold cannot exceed owner count");
+        // There has to be at least one Safe owner.
+        require(_threshold >= 1, "Threshold needs to be greater than 0");
+        // Initializing Safe owners.
+        address currentOwner = SENTINEL_OWNERS;
+        for (uint256 i = 0; i < _owners.length; i++) {
+            // Owner address cannot be null.
+            address owner = _owners[i];
+            require(owner != address(0) && owner != SENTINEL_OWNERS, "Invalid owner address provided");
+            // No duplicate owners allowed.
+            require(owners[owner] == address(0), "Duplicate owner address provided");
+            owners[currentOwner] = owner;
+            currentOwner = owner;
+        }
+        owners[currentOwner] = SENTINEL_OWNERS;
+        ownerCount = _owners.length;
+        threshold = _threshold;
+    }
+
+    /// @dev Allows to add a new owner to the Safe and update the threshold at the same time.
+    ///      This can only be done via a Safe transaction.
+    /// @param owner New owner address.
+    /// @param _threshold New threshold.
+    function addOwnerWithThreshold(address owner, uint256 _threshold)
+        public
+        authorized
+    {
+        // Owner address cannot be null.
+        require(owner != address(0) && owner != SENTINEL_OWNERS, "Invalid owner address provided");
+        // No duplicate owners allowed.
+        require(owners[owner] == address(0), "Address is already an owner");
+        owners[owner] = owners[SENTINEL_OWNERS];
+        owners[SENTINEL_OWNERS] = owner;
+        ownerCount++;
+        emit AddedOwner(owner);
+        // Change threshold if threshold was changed.
+        if (threshold != _threshold)
+            changeThreshold(_threshold);
+    }
+
+    /// @dev Allows to remove an owner from the Safe and update the threshold at the same time.
+    ///      This can only be done via a Safe transaction.
+    /// @param prevOwner Owner that pointed to the owner to be removed in the linked list
+    /// @param owner Owner address to be removed.
+    /// @param _threshold New threshold.
+    function removeOwner(address prevOwner, address owner, uint256 _threshold)
+        public
+        authorized
+    {
+        // Only allow to remove an owner, if threshold can still be reached.
+        require(ownerCount - 1 >= _threshold, "New owner count needs to be larger than new threshold");
+        // Validate owner address and check that it corresponds to owner index.
+        require(owner != address(0) && owner != SENTINEL_OWNERS, "Invalid owner address provided");
+        require(owners[prevOwner] == owner, "Invalid prevOwner, owner pair provided");
+        owners[prevOwner] = owners[owner];
+        owners[owner] = address(0);
+        ownerCount--;
+        emit RemovedOwner(owner);
+        // Change threshold if threshold was changed.
+        if (threshold != _threshold)
+            changeThreshold(_threshold);
+    }
+
+    /// @dev Allows to swap/replace an owner from the Safe with another address.
+    ///      This can only be done via a Safe transaction.
+    /// @param prevOwner Owner that pointed to the owner to be replaced in the linked list
+    /// @param oldOwner Owner address to be replaced.
+    /// @param newOwner New owner address.
+    function swapOwner(address prevOwner, address oldOwner, address newOwner)
+        public
+        authorized
+    {
+        // Owner address cannot be null.
+        require(newOwner != address(0) && newOwner != SENTINEL_OWNERS, "Invalid owner address provided");
+        // No duplicate owners allowed.
+        require(owners[newOwner] == address(0), "Address is already an owner");
+        // Validate oldOwner address and check that it corresponds to owner index.
+        require(oldOwner != address(0) && oldOwner != SENTINEL_OWNERS, "Invalid owner address provided");
+        require(owners[prevOwner] == oldOwner, "Invalid prevOwner, owner pair provided");
+        owners[newOwner] = owners[oldOwner];
+        owners[prevOwner] = newOwner;
+        owners[oldOwner] = address(0);
+        emit RemovedOwner(oldOwner);
+        emit AddedOwner(newOwner);
+    }
+
+    /// @dev Allows to update the number of required confirmations by Safe owners.
+    ///      This can only be done via a Safe transaction.
+    /// @param _threshold New threshold.
+    function changeThreshold(uint256 _threshold)
+        public
+        authorized
+    {
+        // Validate that threshold is smaller than number of owners.
+        require(_threshold <= ownerCount, "Threshold cannot exceed owner count");
+        // There has to be at least one Safe owner.
+        require(_threshold >= 1, "Threshold needs to be greater than 0");
+        threshold = _threshold;
+        emit ChangedThreshold(threshold);
+    }
+
+    function getThreshold()
+        public
+        view
+        returns (uint256)
+    {
+        return threshold;
+    }
+
+    function isOwner(address owner)
+        public
+        view
+        returns (bool)
+    {
+        return owner != SENTINEL_OWNERS && owners[owner] != address(0);
+    }
+
+    /// @dev Returns array of owners.
+    /// @return Array of Safe owners.
+    function getOwners()
+        public
+        view
+        returns (address[] memory)
+    {
+        address[] memory array = new address[](ownerCount);
+
+        // populate return array
+        uint256 index = 0;
+        address currentOwner = owners[SENTINEL_OWNERS];
+        while(currentOwner != SENTINEL_OWNERS) {
+            array[index] = currentOwner;
+            currentOwner = owners[currentOwner];
+            index ++;
+        }
+        return array;
+    }
+}
+
+
+
+
+
+/// @title Fallback Manager - A contract that manages fallback calls made to this contract
+/// @author Richard Meissner - <richard@gnosis.pm>
+contract FallbackManager is SelfAuthorized {
+
+    // keccak256("fallback_manager.handler.address")
+    bytes32 internal constant FALLBACK_HANDLER_STORAGE_SLOT = 0x6c9a6c4a39284e37ed1cf53d337577d14212a4870fb976a4366c693b939918d5;
+
+    function internalSetFallbackHandler(address handler) internal {
+        bytes32 slot = FALLBACK_HANDLER_STORAGE_SLOT;
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            sstore(slot, handler)
+        }
+    }
+
+    /// @dev Allows to add a contract to handle fallback calls.
+    ///      Only fallback calls without value and with data will be forwarded.
+    ///      This can only be done via a Safe transaction.
+    /// @param handler contract to handle fallbacks calls.
+    function setFallbackHandler(address handler)
+        public
+        authorized
+    {
+        internalSetFallbackHandler(handler);
+    }
+
+    function ()
+        external
+        payable
+    {
+        // Only calls without value and with data will be forwarded
+        if (msg.value > 0 || msg.data.length == 0) {
+            return;
+        }
+        bytes32 slot = FALLBACK_HANDLER_STORAGE_SLOT;
+        address handler;
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            handler := sload(slot)
+        }
+
+        if (handler != address(0)) {
+            // solium-disable-next-line security/no-inline-assembly
+            assembly {
+                calldatacopy(0, 0, calldatasize())
+                let success := call(gas, handler, 0, 0, calldatasize(), 0, 0)
+                returndatacopy(0, 0, returndatasize())
+                if eq(success, 0) { revert(0, returndatasize()) }
+                return(0, returndatasize())
+            }
+        }
+    }
+}
+
+
+
+
+
+
+
+/// @title SignatureDecoder - Decodes signatures that a encoded as bytes
+/// @author Ricardo Guilherme Schmidt (Status Research & Development GmbH)
+/// @author Richard Meissner - <richard@gnosis.pm>
+contract SignatureDecoder {
+    
+    /// @dev Recovers address who signed the message
+    /// @param messageHash operation ethereum signed message hash
+    /// @param messageSignature message `txHash` signature
+    /// @param pos which signature to read
+    function recoverKey (
+        bytes32 messageHash,
+        bytes memory messageSignature,
+        uint256 pos
+    )
+        internal
+        pure
+        returns (address)
+    {
+        uint8 v;
+        bytes32 r;
+        bytes32 s;
+        (v, r, s) = signatureSplit(messageSignature, pos);
+        return ecrecover(messageHash, v, r, s);
+    }
+
+    /// @dev divides bytes signature into `uint8 v, bytes32 r, bytes32 s`.
+    /// @notice Make sure to peform a bounds check for @param pos, to avoid out of bounds access on @param signatures
+    /// @param pos which signature to read. A prior bounds check of this parameter should be performed, to avoid out of bounds access
+    /// @param signatures concatenated rsv signatures
+    function signatureSplit(bytes memory signatures, uint256 pos)
+        internal
+        pure
+        returns (uint8 v, bytes32 r, bytes32 s)
+    {
+        // The signature format is a compact form of:
+        //   {bytes32 r}{bytes32 s}{uint8 v}
+        // Compact means, uint8 is not padded to 32 bytes.
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            let signaturePos := mul(0x41, pos)
+            r := mload(add(signatures, add(signaturePos, 0x20)))
+            s := mload(add(signatures, add(signaturePos, 0x40)))
+            // Here we are loading the last 32 bytes, including 31 bytes
+            // of 's'. There is no 'mload8' to do this.
+            //
+            // 'byte' is not working due to the Solidity parser, so lets
+            // use the second best option, 'and'
+            v := and(mload(add(signatures, add(signaturePos, 0x41))), 0xff)
+        }
+    }
+}
+
+
+
+
+contract ISignatureValidatorConstants {
+    // bytes4(keccak256("isValidSignature(bytes,bytes)")
+    bytes4 constant internal EIP1271_MAGIC_VALUE = 0x20c13b0b;
+}
+
+contract ISignatureValidator is ISignatureValidatorConstants {
+
+    /**
+    * @dev Should return whether the signature provided is valid for the provided data
+    * @param _data Arbitrary length data signed on the behalf of address(this)
+    * @param _signature Signature byte array associated with _data
+    *
+    * MUST return the bytes4 magic value 0x20c13b0b when function passes.
+    * MUST NOT modify state (using STATICCALL for solc < 0.5, view modifier for solc > 0.5)
+    * MUST allow external calls
+    */
+    function isValidSignature(
+        bytes memory _data,
+        bytes memory _signature)
+        public
+        view
+        returns (bytes4);
+}
+
+
+/**
+ * @title SafeMath
+ * @dev Math operations with safety checks that revert on error
+ * TODO: remove once open zeppelin update to solc 0.5.0
+ */
+library SafeMath {
+
+  /**
+  * @dev Multiplies two numbers, reverts on overflow.
+  */
+  function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+    // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+    // benefit is lost if 'b' is also tested.
+    // See: https://github.com/OpenZeppelin/openzeppelin-solidity/pull/522
+    if (a == 0) {
+      return 0;
+    }
+
+    uint256 c = a * b;
+    require(c / a == b);
+
+    return c;
+  }
+
+  /**
+  * @dev Integer division of two numbers truncating the quotient, reverts on division by zero.
+  */
+  function div(uint256 a, uint256 b) internal pure returns (uint256) {
+    require(b > 0); // Solidity only automatically asserts when dividing by 0
+    uint256 c = a / b;
+    // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+    return c;
+  }
+
+  /**
+  * @dev Subtracts two numbers, reverts on overflow (i.e. if subtrahend is greater than minuend).
+  */
+  function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+    require(b <= a);
+    uint256 c = a - b;
+
+    return c;
+  }
+
+  /**
+  * @dev Adds two numbers, reverts on overflow.
+  */
+  function add(uint256 a, uint256 b) internal pure returns (uint256) {
+    uint256 c = a + b;
+    require(c >= a);
+
+    return c;
+  }
+
+  /**
+  * @dev Divides two numbers and returns the remainder (unsigned integer modulo),
+  * reverts when dividing by zero.
+  */
+  function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+    require(b != 0);
+    return a % b;
+  }
+}
+
+/// @title Gnosis Safe - A multisignature wallet with support for confirmations using signed messages based on ERC191.
+/// @author Stefan George - <stefan@gnosis.io>
+/// @author Richard Meissner - <richard@gnosis.io>
+/// @author Ricardo Guilherme Schmidt - (Status Research & Development GmbH) - Gas Token Payment
+contract GnosisSafe
+    is MasterCopy, ModuleManager, OwnerManager, SignatureDecoder, SecuredTokenTransfer, ISignatureValidatorConstants, FallbackManager {
+
+    using SafeMath for uint256;
+
+    string public constant NAME = "Gnosis Safe";
+    string public constant VERSION = "1.1.1";
+
+    //keccak256(
+    //    "EIP712Domain(address verifyingContract)"
+    //);
+    bytes32 private constant DOMAIN_SEPARATOR_TYPEHASH = 0x035aff83d86937d35b32e04f0ddc6ff469290eef2f1b692d8a815c89404d4749;
+
+    //keccak256(
+    //    "SafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,uint256 nonce)"
+    //);
+    bytes32 private constant SAFE_TX_TYPEHASH = 0xbb8310d486368db6bd6f849402fdd73ad53d316b5a4b2644ad6efe0f941286d8;
+
+    //keccak256(
+    //    "SafeMessage(bytes message)"
+    //);
+    bytes32 private constant SAFE_MSG_TYPEHASH = 0x60b3cbf8b4a223d68d641b3b6ddf9a298e7f33710cf3d3a9d1146b5a6150fbca;
+
+    event ApproveHash(
+        bytes32 indexed approvedHash,
+        address indexed owner
+    );
+    event SignMsg(
+        bytes32 indexed msgHash
+    );
+    event ExecutionFailure(
+        bytes32 txHash, uint256 payment
+    );
+    event ExecutionSuccess(
+        bytes32 txHash, uint256 payment
+    );
+
+    uint256 public nonce;
+    bytes32 public domainSeparator;
+    // Mapping to keep track of all message hashes that have been approve by ALL REQUIRED owners
+    mapping(bytes32 => uint256) public signedMessages;
+    // Mapping to keep track of all hashes (message or transaction) that have been approve by ANY owners
+    mapping(address => mapping(bytes32 => uint256)) public approvedHashes;
+
+    // This constructor ensures that this contract can only be used as a master copy for Proxy contracts
+    constructor() public {
+        // By setting the threshold it is not possible to call setup anymore,
+        // so we create a Safe with 0 owners and threshold 1.
+        // This is an unusable Safe, perfect for the mastercopy
+        threshold = 1;
+    }
+
+    /// @dev Setup function sets initial storage of contract.
+    /// @param _owners List of Safe owners.
+    /// @param _threshold Number of required confirmations for a Safe transaction.
+    /// @param to Contract address for optional delegate call.
+    /// @param data Data payload for optional delegate call.
+    /// @param fallbackHandler Handler for fallback calls to this contract
+    /// @param paymentToken Token that should be used for the payment (0 is ETH)
+    /// @param payment Value that should be paid
+    /// @param paymentReceiver Adddress that should receive the payment (or 0 if tx.origin)
+    function setup(
+        address[] calldata _owners,
+        uint256 _threshold,
+        address to,
+        bytes calldata data,
+        address fallbackHandler,
+        address paymentToken,
+        uint256 payment,
+        address payable paymentReceiver
+    )
+        external
+    {
+        require(domainSeparator == 0, "Domain Separator already set!");
+        domainSeparator = keccak256(abi.encode(DOMAIN_SEPARATOR_TYPEHASH, this));
+        setupOwners(_owners, _threshold);
+        if (fallbackHandler != address(0)) internalSetFallbackHandler(fallbackHandler);
+        // As setupOwners can only be called if the contract has not been initialized we don't need a check for setupModules
+        setupModules(to, data);
+
+        if (payment > 0) {
+            // To avoid running into issues with EIP-170 we reuse the handlePayment function (to avoid adjusting code of that has been verified we do not adjust the method itself)
+            // baseGas = 0, gasPrice = 1 and gas = payment => amount = (payment + 0) * 1 = payment
+            handlePayment(payment, 0, 1, paymentToken, paymentReceiver);
+        }
+    }
+
+    /// @dev Allows to execute a Safe transaction confirmed by required number of owners and then pays the account that submitted the transaction.
+    ///      Note: The fees are always transfered, even if the user transaction fails.
+    /// @param to Destination address of Safe transaction.
+    /// @param value Ether value of Safe transaction.
+    /// @param data Data payload of Safe transaction.
+    /// @param operation Operation type of Safe transaction.
+    /// @param safeTxGas Gas that should be used for the Safe transaction.
+    /// @param baseGas Gas costs for that are indipendent of the transaction execution(e.g. base transaction fee, signature check, payment of the refund)
+    /// @param gasPrice Gas price that should be used for the payment calculation.
+    /// @param gasToken Token address (or 0 if ETH) that is used for the payment.
+    /// @param refundReceiver Address of receiver of gas payment (or 0 if tx.origin).
+    /// @param signatures Packed signature data ({bytes32 r}{bytes32 s}{uint8 v})
+    function execTransaction(
+        address to,
+        uint256 value,
+        bytes calldata data,
+        Enum.Operation operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address payable refundReceiver,
+        bytes calldata signatures
+    )
+        external
+        returns (bool success)
+    {
+        bytes32 txHash;
+        // Use scope here to limit variable lifetime and prevent `stack too deep` errors
+        {
+            bytes memory txHashData = encodeTransactionData(
+                to, value, data, operation, // Transaction info
+                safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, // Payment info
+                nonce
+            );
+            // Increase nonce and execute transaction.
+            nonce++;
+            txHash = keccak256(txHashData);
+            checkSignatures(txHash, txHashData, signatures, true);
+        }
+        require(gasleft() >= safeTxGas, "Not enough gas to execute safe transaction");
+        // Use scope here to limit variable lifetime and prevent `stack too deep` errors
+        {
+            uint256 gasUsed = gasleft();
+            // If no safeTxGas has been set and the gasPrice is 0 we assume that all available gas can be used
+            success = execute(to, value, data, operation, safeTxGas == 0 && gasPrice == 0 ? gasleft() : safeTxGas);
+            gasUsed = gasUsed.sub(gasleft());
+            // We transfer the calculated tx costs to the tx.origin to avoid sending it to intermediate contracts that have made calls
+            uint256 payment = 0;
+            if (gasPrice > 0) {
+                payment = handlePayment(gasUsed, baseGas, gasPrice, gasToken, refundReceiver);
+            }
+            if (success) emit ExecutionSuccess(txHash, payment);
+            else emit ExecutionFailure(txHash, payment);
+        }
+    }
+
+    function handlePayment(
+        uint256 gasUsed,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address payable refundReceiver
+    )
+        private
+        returns (uint256 payment)
+    {
+        // solium-disable-next-line security/no-tx-origin
+        address payable receiver = refundReceiver == address(0) ? tx.origin : refundReceiver;
+        if (gasToken == address(0)) {
+            // For ETH we will only adjust the gas price to not be higher than the actual used gas price
+            payment = gasUsed.add(baseGas).mul(gasPrice < tx.gasprice ? gasPrice : tx.gasprice);
+            // solium-disable-next-line security/no-send
+            require(receiver.send(payment), "Could not pay gas costs with ether");
+        } else {
+            payment = gasUsed.add(baseGas).mul(gasPrice);
+            require(transferToken(gasToken, receiver, payment), "Could not pay gas costs with token");
+        }
+    }
+
+    /**
+    * @dev Checks whether the signature provided is valid for the provided data, hash. Will revert otherwise.
+    * @param dataHash Hash of the data (could be either a message hash or transaction hash)
+    * @param data That should be signed (this is passed to an external validator contract)
+    * @param signatures Signature data that should be verified. Can be ECDSA signature, contract signature (EIP-1271) or approved hash.
+    * @param consumeHash Indicates that in case of an approved hash the storage can be freed to save gas
+    */
+    function checkSignatures(bytes32 dataHash, bytes memory data, bytes memory signatures, bool consumeHash)
+        internal
+    {
+        // Load threshold to avoid multiple storage loads
+        uint256 _threshold = threshold;
+        // Check that a threshold is set
+        require(_threshold > 0, "Threshold needs to be defined!");
+        // Check that the provided signature data is not too short
+        require(signatures.length >= _threshold.mul(65), "Signatures data too short");
+        // There cannot be an owner with address 0.
+        address lastOwner = address(0);
+        address currentOwner;
+        uint8 v;
+        bytes32 r;
+        bytes32 s;
+        uint256 i;
+        for (i = 0; i < _threshold; i++) {
+            (v, r, s) = signatureSplit(signatures, i);
+            // If v is 0 then it is a contract signature
+            if (v == 0) {
+                // When handling contract signatures the address of the contract is encoded into r
+                currentOwner = address(uint256(r));
+
+                // Check that signature data pointer (s) is not pointing inside the static part of the signatures bytes
+                // This check is not completely accurate, since it is possible that more signatures than the threshold are send.
+                // Here we only check that the pointer is not pointing inside the part that is being processed
+                require(uint256(s) >= _threshold.mul(65), "Invalid contract signature location: inside static part");
+
+                // Check that signature data pointer (s) is in bounds (points to the length of data -> 32 bytes)
+                require(uint256(s).add(32) <= signatures.length, "Invalid contract signature location: length not present");
+
+                // Check if the contract signature is in bounds: start of data is s + 32 and end is start + signature length
+                uint256 contractSignatureLen;
+                // solium-disable-next-line security/no-inline-assembly
+                assembly {
+                    contractSignatureLen := mload(add(add(signatures, s), 0x20))
+                }
+                require(uint256(s).add(32).add(contractSignatureLen) <= signatures.length, "Invalid contract signature location: data not complete");
+
+                // Check signature
+                bytes memory contractSignature;
+                // solium-disable-next-line security/no-inline-assembly
+                assembly {
+                    // The signature data for contract signatures is appended to the concatenated signatures and the offset is stored in s
+                    contractSignature := add(add(signatures, s), 0x20)
+                }
+                require(ISignatureValidator(currentOwner).isValidSignature(data, contractSignature) == EIP1271_MAGIC_VALUE, "Invalid contract signature provided");
+            // If v is 1 then it is an approved hash
+            } else if (v == 1) {
+                // When handling approved hashes the address of the approver is encoded into r
+                currentOwner = address(uint256(r));
+                // Hashes are automatically approved by the sender of the message or when they have been pre-approved via a separate transaction
+                require(msg.sender == currentOwner || approvedHashes[currentOwner][dataHash] != 0, "Hash has not been approved");
+                // Hash has been marked for consumption. If this hash was pre-approved free storage
+                if (consumeHash && msg.sender != currentOwner) {
+                    approvedHashes[currentOwner][dataHash] = 0;
+                }
+            } else if (v > 30) {
+                // To support eth_sign and similar we adjust v and hash the messageHash with the Ethereum message prefix before applying ecrecover
+                currentOwner = ecrecover(keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", dataHash)), v - 4, r, s);
+            } else {
+                // Use ecrecover with the messageHash for EOA signatures
+                currentOwner = ecrecover(dataHash, v, r, s);
+            }
+            require (
+                currentOwner > lastOwner && owners[currentOwner] != address(0) && currentOwner != SENTINEL_OWNERS,
+                "Invalid owner provided"
+            );
+            lastOwner = currentOwner;
+        }
+    }
+
+    /// @dev Allows to estimate a Safe transaction.
+    ///      This method is only meant for estimation purpose, therefore two different protection mechanism against execution in a transaction have been made:
+    ///      1.) The method can only be called from the safe itself
+    ///      2.) The response is returned with a revert
+    ///      When estimating set `from` to the address of the safe.
+    ///      Since the `estimateGas` function includes refunds, call this method to get an estimated of the costs that are deducted from the safe with `execTransaction`
+    /// @param to Destination address of Safe transaction.
+    /// @param value Ether value of Safe transaction.
+    /// @param data Data payload of Safe transaction.
+    /// @param operation Operation type of Safe transaction.
+    /// @return Estimate without refunds and overhead fees (base transaction and payload data gas costs).
+    function requiredTxGas(address to, uint256 value, bytes calldata data, Enum.Operation operation)
+        external
+        authorized
+        returns (uint256)
+    {
+        uint256 startGas = gasleft();
+        // We don't provide an error message here, as we use it to return the estimate
+        // solium-disable-next-line error-reason
+        require(execute(to, value, data, operation, gasleft()));
+        uint256 requiredGas = startGas - gasleft();
+        // Convert response to string and return via error message
+        revert(string(abi.encodePacked(requiredGas)));
+    }
+
+    /**
+    * @dev Marks a hash as approved. This can be used to validate a hash that is used by a signature.
+    * @param hashToApprove The hash that should be marked as approved for signatures that are verified by this contract.
+    */
+    function approveHash(bytes32 hashToApprove)
+        external
+    {
+        require(owners[msg.sender] != address(0), "Only owners can approve a hash");
+        approvedHashes[msg.sender][hashToApprove] = 1;
+        emit ApproveHash(hashToApprove, msg.sender);
+    }
+
+    /**
+    * @dev Marks a message as signed
+    * @param _data Arbitrary length data that should be marked as signed on the behalf of address(this)
+    */
+    function signMessage(bytes calldata _data)
+        external
+        authorized
+    {
+        bytes32 msgHash = getMessageHash(_data);
+        signedMessages[msgHash] = 1;
+        emit SignMsg(msgHash);
+    }
+
+    /**
+    * Implementation of ISignatureValidator (see `interfaces/ISignatureValidator.sol`)
+    * @dev Should return whether the signature provided is valid for the provided data.
+    *       The save does not implement the interface since `checkSignatures` is not a view method.
+    *       The method will not perform any state changes (see parameters of `checkSignatures`)
+    * @param _data Arbitrary length data signed on the behalf of address(this)
+    * @param _signature Signature byte array associated with _data
+    * @return a bool upon valid or invalid signature with corresponding _data
+    */
+    function isValidSignature(bytes calldata _data, bytes calldata _signature)
+        external
+        returns (bytes4)
+    {
+        bytes32 messageHash = getMessageHash(_data);
+        if (_signature.length == 0) {
+            require(signedMessages[messageHash] != 0, "Hash not approved");
+        } else {
+            // consumeHash needs to be false, as the state should not be changed
+            checkSignatures(messageHash, _data, _signature, false);
+        }
+        return EIP1271_MAGIC_VALUE;
+    }
+
+    /// @dev Returns hash of a message that can be signed by owners.
+    /// @param message Message that should be hashed
+    /// @return Message hash.
+    function getMessageHash(
+        bytes memory message
+    )
+        public
+        view
+        returns (bytes32)
+    {
+        bytes32 safeMessageHash = keccak256(
+            abi.encode(SAFE_MSG_TYPEHASH, keccak256(message))
+        );
+        return keccak256(
+            abi.encodePacked(byte(0x19), byte(0x01), domainSeparator, safeMessageHash)
+        );
+    }
+
+    /// @dev Returns the bytes that are hashed to be signed by owners.
+    /// @param to Destination address.
+    /// @param value Ether value.
+    /// @param data Data payload.
+    /// @param operation Operation type.
+    /// @param safeTxGas Fas that should be used for the safe transaction.
+    /// @param baseGas Gas costs for data used to trigger the safe transaction.
+    /// @param gasPrice Maximum gas price that should be used for this transaction.
+    /// @param gasToken Token address (or 0 if ETH) that is used for the payment.
+    /// @param refundReceiver Address of receiver of gas payment (or 0 if tx.origin).
+    /// @param _nonce Transaction nonce.
+    /// @return Transaction hash bytes.
+    function encodeTransactionData(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address refundReceiver,
+        uint256 _nonce
+    )
+        public
+        view
+        returns (bytes memory)
+    {
+        bytes32 safeTxHash = keccak256(
+            abi.encode(SAFE_TX_TYPEHASH, to, value, keccak256(data), operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, _nonce)
+        );
+        return abi.encodePacked(byte(0x19), byte(0x01), domainSeparator, safeTxHash);
+    }
+
+    /// @dev Returns hash to be signed by owners.
+    /// @param to Destination address.
+    /// @param value Ether value.
+    /// @param data Data payload.
+    /// @param operation Operation type.
+    /// @param safeTxGas Fas that should be used for the safe transaction.
+    /// @param baseGas Gas costs for data used to trigger the safe transaction.
+    /// @param gasPrice Maximum gas price that should be used for this transaction.
+    /// @param gasToken Token address (or 0 if ETH) that is used for the payment.
+    /// @param refundReceiver Address of receiver of gas payment (or 0 if tx.origin).
+    /// @param _nonce Transaction nonce.
+    /// @return Transaction hash.
+    function getTransactionHash(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address refundReceiver,
+        uint256 _nonce
+    )
+        public
+        view
+        returns (bytes32)
+    {
+        return keccak256(encodeTransactionData(to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, _nonce));
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -45,6 +45,8 @@ module.exports = {
       }
     ],
     overrides: {
+      "contracts/utils/GnosisSafe/GnosisProxy.sol": { version: "0.5.14" },
+      "contracts/utils/GnosisSafe/GnosisSafe.sol": { version: "0.5.14" },
       "contracts/omen/OMNToken.sol": { version: "0.7.6" },
       "contracts/omen/OMNGuild.sol": {
         version: "0.7.6",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-standard": "^3.0.1",
     "ethereumjs-abi": "^0.6.5",
     "ethers": "^5.1.0",
-    "hardhat": "^2.0.8",
+    "hardhat": "^2.2.0",
     "hardhat-gas-reporter": "^1.0.4",
     "pm2": "^2.9.3",
     "promisify": "^0.0.3",

--- a/test/contributionrewards.js
+++ b/test/contributionrewards.js
@@ -10,6 +10,9 @@ const DaoCreator = artifacts.require("./DaoCreator.sol");
 const ControllerCreator = artifacts.require("./DxControllerCreator.sol");
 const Avatar = artifacts.require("./DxAvatar.sol");
 const Redeemer = artifacts.require("./Redeemer.sol");
+const ETHRelayer = artifacts.require("./ETHRelayer.sol");
+const GnosisProxy = artifacts.require("./GnosisProxy.sol");
+const GnosisSafe = artifacts.require("./GnosisSafe.sol");
 
 const { BN, expectEvent, expectRevert, time } = require("@openzeppelin/test-helpers");
 
@@ -236,6 +239,63 @@ contract('ContributionReward', (accounts) => {
       var eth = await web3.eth.getBalance(otherAvatar.address);
       assert.equal(eth,ethReward);
      });
+     
+     it("execute proposeContributionReward to expensive receiver fallback function will fail in redeem", async function() {
+       var testSetup = await setup(accounts);
+       var ethReward = 666;
+       var periodLength = 50;
+       var numberOfPeriods = 1;
+       //send some ether to the org avatar
+       var gnosisSafe = await GnosisSafe.new();
+       var gnosisProxy = await GnosisProxy.new(gnosisSafe.address);
+       await web3.eth.sendTransaction({from:accounts[0], to:testSetup.org.avatar.address, value: 666});
+       var tx = await testSetup.contributionReward.proposeContributionReward(
+         testSetup.org.avatar.address,
+         web3.utils.asciiToHex("description"),
+         0,
+         [0 , ethReward, 0, periodLength, numberOfPeriods],
+         testSetup.standardTokenMock.address,
+         gnosisProxy.address
+       );
+       //Vote with reputation to trigger execution
+       var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
+       await testSetup.contributionRewardParams.votingMachine.contract.vote(proposalId,1,0,constants.NULL_ADDRESS,{from:accounts[2]});
+       await time.increase(periodLength+1);
+       try {
+         await testSetup.contributionReward.redeem(proposalId, testSetup.org.avatar.address,[false,false,true,false]);
+       } catch (e) {
+         assert.equal(e, "Error: Transaction reverted without a reason");
+       }
+       assert.equal(await web3.eth.getBalance(gnosisProxy.address), 0);
+     });
+     
+    it("execute proposeContributionReward send across relayer ", async function() {
+      var testSetup = await setup(accounts);
+      var ethReward = 666;
+      var periodLength = 50;
+      var numberOfPeriods = 1;
+      //send some ether to the org avatar
+      var gnosisSafe = await GnosisSafe.new();
+      var gnosisProxy = await GnosisProxy.new(gnosisSafe.address);
+      var ethRelayer = await ETHRelayer.new(gnosisProxy.address);
+      await web3.eth.sendTransaction({from:accounts[0], to:testSetup.org.avatar.address, value: 666});
+      var tx = await testSetup.contributionReward.proposeContributionReward(
+        testSetup.org.avatar.address,
+        web3.utils.asciiToHex("description"),
+        0,
+        [0 , ethReward, 0, periodLength, numberOfPeriods],
+        testSetup.standardTokenMock.address,
+        ethRelayer.address
+      );
+      //Vote with reputation to trigger execution
+      var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
+      await testSetup.contributionRewardParams.votingMachine.contract.vote(proposalId,1,0,constants.NULL_ADDRESS,{from:accounts[2]});
+      await time.increase(periodLength+1);
+      await testSetup.contributionReward.redeem(proposalId, testSetup.org.avatar.address,[false,false,true,false]);
+      assert.equal(await web3.eth.getBalance(ethRelayer.address) ,ethReward);
+      await ethRelayer.relay();
+      assert.equal(await web3.eth.getBalance(gnosisProxy.address) ,ethReward);
+    });
 
     it("execute proposeContributionReward  send externalToken ", async function() {
       var testSetup = await setup(accounts);


### PR DESCRIPTION
After Berlin fork some opcodes are more expensive to be executed, this caused the ContributionReward proposals to fail when they are being redeemed since the fallback receiver function now is more expensive in the computation cost than it was before.

A smart contract called ETHRelayer was added with tests simulating and showing how and were the "redeem" was failing, this ETHRelayer can receive ETH with the default cost of 23000 gas and it will relay the ETH to a receiver address using a default of 100000 gas limit, this is more than enough in the GnosisSafe with GnosisProxy to receive the ETH.